### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "math-expression-evaluator": "^1.2.17",
     "moment": "^2.22.2",
     "node-opus": "^0.3.0",
-    "npm": "^6.2.0",
     "opusscript": "0.0.6",
     "pretty-ms": "^3.2.0",
     "queue": "^4.4.2",


### PR DESCRIPTION

Hello ProfeSSorAlaa!

It seems like you have npm as one of your (dev-) dependency in Sys-Bot.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
